### PR TITLE
Raise exception when import_records fails

### DIFF
--- a/redcap/project.py
+++ b/redcap/project.py
@@ -99,7 +99,7 @@ class Project(object):
         arms: list
             Limit exported form event mappings to these arm numbers
         format: {'obj', 'csv', 'xml'} default obj
-            Return the form event mappings in native objects, 
+            Return the form event mappings in native objects,
             csv or xml, df will return a pandas.DataFrame
         df_kwargs: dict
             Passed to pandas.read_csv to control construction of
@@ -347,7 +347,10 @@ class Project(object):
         pl['format'] = format
         pl['returnFormat'] = return_format
         pl['returnContent'] = return_content
-        return self._call_api(pl, 'imp_record')[0]
+        response = self._call_api(pl, 'imp_record')[0]
+        if 'error' in response:
+            raise RedcapError(str(response))
+        return response
 
     def export_file(self, record, field, event=None, return_format='json'):
         """ Export the contents of a file stored for a particular record

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -71,6 +71,22 @@ class ProjectTests(unittest.TestCase):
         for record in data:
             self.assertIsInstance(record, dict)
 
+    def test_import_records(self):
+        "Test record import"
+        data = self.reg_proj.export_records()
+        response = self.reg_proj.import_records(data)
+        self.assertIn('count', response)
+        self.assertNotIn('error', response)
+
+    def test_import_exception(self):
+        "Test record import throws RedcapError for bad import"
+        data = self.reg_proj.export_records()
+        data[0]['non_existent_key'] = 'foo'
+        with self.assertRaises(RedcapError) as cm:
+            self.reg_proj.import_records(data)
+        exc = cm.exception
+        self.assertIn('error', exc.args[0])
+
     def is_good_csv(self, csv_string):
         "Helper to test csv strings"
         return isinstance(csv_string, basestring)


### PR DESCRIPTION
Fixes #20

Also adds:
- test that regular import works
- test that bad import throws RedcapError
