### PR TITLE
Add support for testing recent Python 3 versions in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "2.7"
+  - "3.6"
+  - "3.7"
 # command to install dependencies
 install:
   # install numpy and pandas for full-suite testing


### PR DESCRIPTION
Python 2.x support is [ending soon](https://pythonclock.org) -- let's get tests running against recent versions of Python 3.

It seems (potentially during the transition from sburns -> redcap-tools?) that TravisCI was left unmaintained. I could help with this if you'd like!