### PR TITLE
Export Project Information

### DIFF
--- a/redcap/project.py
+++ b/redcap/project.py
@@ -656,6 +656,15 @@ class Project(object):
         return self._call_api(pl, 'exp_survey_participant_list')
 
     def export_project_info(self, format='json'):
+        """
+        Export Project Information
+
+        Parameters
+        ----------
+        format: (json, xml, csv), json by default
+            Format of returned data
+        """
+
         pl = self.__basepl(content='project', format=format)
 
         return self._call_api(pl, 'exp_proj')[0]

--- a/redcap/project.py
+++ b/redcap/project.py
@@ -654,3 +654,8 @@ class Project(object):
         if event:
             pl['event'] = event
         return self._call_api(pl, 'exp_survey_participant_list')
+
+    def export_project_info(self, format='json'):
+        pl = self.__basepl(content='project', format=format)
+
+        return self._call_api(pl, 'exp_proj')[0]

--- a/redcap/request.py
+++ b/redcap/request.py
@@ -83,6 +83,8 @@ class RCRequest(object):
                 'Exporting arms but content is not arm'),
             'exp_fem': (['format'], 'formEventMapping',
                 'Exporting form-event mappings but content != formEventMapping'),
+            'exp_proj': (['format'], 'project',
+                'Exporting project info but content is not project'),
             'exp_user': (['format'], 'user',
                 'Exporting users but content is not user'),
             'exp_survey_participant_list': (['instrument'], 'participantList',

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -634,6 +634,7 @@ class ProjectTests(unittest.TestCase):
 
     @responses.activate
     def test_export_project_info(self):
+        "Test export of project information"
         self.add_normalproject_response()
 
         info = self.reg_proj.export_project_info()

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -101,6 +101,8 @@ class ProjectTests(unittest.TestCase):
             data = urlparse.parse_qs(parsed.query)
             headers = {"Content-Type": "application/json"}
 
+            resp = None
+
             if " filename" in data:
                 resp = {}
             else:
@@ -186,6 +188,15 @@ class ProjectTests(unittest.TestCase):
                             'forms': "test"
                         }
                     ]
+                elif (request_type == "project"):
+                    resp = {
+                        'project_id': 123
+                    }
+
+                self.assertIsNotNone(
+                    resp,
+                    msg="No response for request_type '{}'".format(request_type)
+                )
 
             return (201, headers, json.dumps(resp))
 
@@ -620,3 +631,11 @@ class ProjectTests(unittest.TestCase):
         records = self.reg_proj.export_records(fields=['foo_score'])
         for record in records:
             self.assertIn(self.reg_proj.def_field, record)
+
+    @responses.activate
+    def test_export_project_info(self):
+        self.add_normalproject_response()
+
+        info = self.reg_proj.export_project_info()
+
+        self.assertEqual(info['project_id'], 123)


### PR DESCRIPTION
I've added support for the Export Project Information API call
![redcap-api-export-project-info](https://user-images.githubusercontent.com/192929/71020084-92c8db00-20f3-11ea-9803-68b61836fd27.png)

https://github.com/redcap-tools/PyCap/issues/65 discusses how this might be called on project initialisation and used to replace some of the existing code (e.g. that determines if the project is longitudinal etc). I've not done that. For now this just allows the project information to be retrieved post-initialisation. 