### PR TITLE
Generate Next Record Name

### DIFF
--- a/redcap/project.py
+++ b/redcap/project.py
@@ -654,3 +654,8 @@ class Project(object):
         if event:
             pl['event'] = event
         return self._call_api(pl, 'exp_survey_participant_list')
+
+    def generate_next_record_name(self):
+        pl = self.__basepl(content='generateNextRecordName')
+
+        return self._call_api(pl, 'exp_next_id')[0]

--- a/redcap/request.py
+++ b/redcap/request.py
@@ -83,6 +83,8 @@ class RCRequest(object):
                 'Exporting arms but content is not arm'),
             'exp_fem': (['format'], 'formEventMapping',
                 'Exporting form-event mappings but content != formEventMapping'),
+            'exp_next_id': ([], 'generateNextRecordName',
+                'Generating next record name but content is not generateNextRecordName'),
             'exp_user': (['format'], 'user',
                 'Exporting users but content is not user'),
             'exp_survey_participant_list': (['instrument'], 'participantList',

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -186,6 +186,8 @@ class ProjectTests(unittest.TestCase):
                             'forms': "test"
                         }
                     ]
+                elif (request_type == "generateNextRecordName"):
+                    resp = 123
 
             return (201, headers, json.dumps(resp))
 
@@ -620,3 +622,12 @@ class ProjectTests(unittest.TestCase):
         records = self.reg_proj.export_records(fields=['foo_score'])
         for record in records:
             self.assertIn(self.reg_proj.def_field, record)
+
+    @responses.activate
+    def test_generate_next_record_name(self):
+        "Test exporting the next potential record ID for a project"
+        self.add_normalproject_response()
+
+        next_name = self.reg_proj.generate_next_record_name()
+
+        self.assertEqual(next_name, 123)


### PR DESCRIPTION
I've added support for the Generate Next Record Name API call
![redcap-api-generate-next-record-name](https://user-images.githubusercontent.com/192929/71021473-58ad0880-20f6-11ea-93f8-ae9f47926f28.png)
