### PR TITLE
Allow later versions of semantic-version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def get_version():
 
 required = [
     'requests>=1.0.0',
-    'semantic-version==2.3.1'
+    'semantic-version>=2.3.1'
 ]
 
 if __name__ == '__main__':


### PR DESCRIPTION
This prevents pip dependency conflicts if a later version of semantic-version is
required elsewhere