### PR TITLE
Change API parameters from comma-separated to arrays

### DIFF
--- a/redcap/project.py
+++ b/redcap/project.py
@@ -179,11 +179,11 @@ class Project(object):
             from pandas import read_csv
             ret_format = 'csv'
         pl = self.__basepl('formEventMapping', format=ret_format)
-        to_add = [arms]
-        str_add = ['arms']
-        for key, data in zip(str_add, to_add):
-            if data:
-                pl[key] = ','.join(data)
+
+        if arms:
+            for i, value in enumerate(arms):
+                pl["arms[{}]".format(i)] = value
+
         response, _ = self._call_api(pl, 'exp_fem')
         if format in ('json', 'csv', 'xml'):
             return response
@@ -226,7 +226,9 @@ class Project(object):
         str_add = ['fields', 'forms']
         for key, data in zip(str_add, to_add):
             if data:
-                pl[key] = ','.join(data)
+                for i, value in enumerate(data):
+                    pl["{}[{}]".format(key, i)] = value
+
         response, _ = self._call_api(pl, 'metadata')
         if format in ('json', 'csv', 'xml'):
             return response
@@ -311,9 +313,9 @@ class Project(object):
         'exportCheckboxLabel')
         for key, data in zip(str_keys, keys_to_add):
             if data:
-                #  Make a url-ok string
                 if key in ('fields', 'records', 'forms', 'events'):
-                    pl[key] = ','.join(data)
+                    for i, value in enumerate(data):
+                        pl["{}[{}]".format(key, i)] = value
                 else:
                     pl[key] = data
 
@@ -665,7 +667,7 @@ class Project(object):
         pl = self.__basepl(content='generateNextRecordName')
 
         return self._call_api(pl, 'exp_next_id')[0]
-      
+
     def export_project_info(self, format='json'):
         """
         Export Project Information

--- a/redcap/request.py
+++ b/redcap/request.py
@@ -172,3 +172,6 @@ class RCRequest(object):
         # specifically 10.5
         if 500 <= r.status_code < 600:
             raise RedcapError(r.content)
+
+        if 400 == r.status_code and self.type == 'exp_record':
+            raise RedcapError(r.content)

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -30,6 +30,9 @@ except NameError:
         return isinstance(s, bytes)
 
 
+from unittest import mock
+
+
 class ProjectTests(unittest.TestCase):
     """docstring for ProjectTests"""
 
@@ -392,6 +395,23 @@ class ProjectTests(unittest.TestCase):
         csv = self.reg_proj.export_metadata(format='csv')
         self.assertTrue(self.is_good_csv(csv))
 
+    def test_metadata_export_passes_filters_as_arrays(self):
+        self.reg_proj._call_api = mock.Mock()
+        self.reg_proj._call_api.return_value = (None, None)
+        self.reg_proj.export_metadata(
+            fields=['field0', 'field1', 'field2'],
+            forms=['form0', 'form1', 'form2'],
+        )
+
+        args, _ = self.reg_proj._call_api.call_args
+
+        payload = args[0]
+
+        self.assertEqual(payload['fields[0]'], 'field0')
+        self.assertEqual(payload['fields[1]'], 'field1')
+        self.assertEqual(payload['fields[2]'], 'field2')
+        self.assertEqual(payload['forms[2]'], 'form2')
+
     def test_bad_creds(self):
         "Test that exceptions are raised with bad URL or tokens"
         with self.assertRaises(RedcapError):
@@ -407,6 +427,21 @@ class ProjectTests(unittest.TestCase):
         self.assertIsInstance(fem, list)
         for arm in fem:
             self.assertIsInstance(arm, dict)
+
+    def test_fem_export_passes_filters_as_arrays(self):
+        self.reg_proj._call_api = mock.Mock()
+        self.reg_proj._call_api.return_value = (None, None)
+        self.reg_proj.export_fem(
+            arms=['arm0', 'arm1', 'arm2'],
+        )
+
+        args, _ = self.reg_proj._call_api.call_args
+
+        payload = args[0]
+
+        self.assertEqual(payload['arms[0]'], 'arm0')
+        self.assertEqual(payload['arms[1]'], 'arm1')
+        self.assertEqual(payload['arms[2]'], 'arm2')
 
     @responses.activate
     def test_file_export(self):
@@ -633,6 +668,27 @@ class ProjectTests(unittest.TestCase):
         records = self.reg_proj.export_records(fields=['foo_score'])
         for record in records:
             self.assertIn(self.reg_proj.def_field, record)
+
+    def test_export_passes_filters_as_arrays(self):
+        self.reg_proj._call_api = mock.Mock()
+        self.reg_proj._call_api.return_value = (None, None)
+        self.reg_proj.export_records(
+            records=['record0', 'record1', 'record2'],
+            fields=['field0', 'field1', 'field2'],
+            forms=['form0', 'form1', 'form2'],
+            events=['event0', 'event1', 'event2']
+        )
+
+        args, _ = self.reg_proj._call_api.call_args
+
+        payload = args[0]
+
+        self.assertEqual(payload['records[0]'], 'record0')
+        self.assertEqual(payload['records[1]'], 'record1')
+        self.assertEqual(payload['records[2]'], 'record2')
+        self.assertEqual(payload['fields[1]'], 'field1')
+        self.assertEqual(payload['forms[2]'], 'form2')
+        self.assertEqual(payload['events[0]'], 'event0')
 
     @responses.activate
     def test_generate_next_record_name(self):

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -29,8 +29,10 @@ except NameError:
     def is_bytestring(s):
         return isinstance(s, bytes)
 
-
-from unittest import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 class ProjectTests(unittest.TestCase):


### PR DESCRIPTION
According to the REDCap developers multiple API parameters should not be comma-separated and should be  represented as arrays instead. So I've changed PyCap to work in this way.

Background:
I noticed that when I passed an invalid form to `Project.export_records()`, I got all records for all forms. If I passed valid forms I got the records I expected for just those forms.

In the REDCap API playground (at least for version 9.5.13 which we're using) the example curl commands do not have the parameters comma-separated. Experimenting with curl:

 ```
   /usr/bin/curl -H Content-Type: application/x-www-form-urlencoded -H Accept: application/json -X POST -d token=MYTOKEN&content=record&format=json&type=flat&fields[0]=record_id&forms[0]=bmi&forms[1]=patient_record&forms[2]=flooble&rawOrLabel=raw&rawOrLabelHeaders=raw&exportCheckboxLabel=false&exportSurveyFields=false&exportDataAccessGroups=false&returnFormat=json https://myserver/api/
          
    /usr/bin/curl -H Content-Type: application/x-www-form-urlencoded -H Accept: application/json -X POST -d token=MYTOKEN&content=record&format=json&type=flat&fields[0]=record_id&forms=bmi,patient_record,flooble&rawOrLabel=raw&rawOrLabelHeaders=raw&exportCheckboxLabel=false&exportSurveyFields=false&exportDataAccessGroups=false&returnFormat=json https://myserver/api/
```

In the first case I got:

`    {"error":"The following values in the parameter \"forms\" are not valid: 'flooble'"}`

In the second case it's as if the forms parameter was omitted and I get results for all forms. If I remove 'flooble' from the list of forms so the parameter is

`    forms=bmi,patient_record`

I get results for just those two forms

I asked the question in the (members only) forum:
https://community.projectredcap.org/questions/77217/export-records-api-silently-ignores-invalid-form-w.html

and it seems that even though comma separated values is working in some cases, the REDCap developers say that the correct way to call the API is with arrays.

So I've changed `export_records(), export_metadata() and export_fem()`. Oddly export_records() is the only call that returns a BadRequest if it gets and invalid form. So I'm also handling that.