### PR TITLE
Implement static package versioning

### DIFF
--- a/redcap/__init__.py
+++ b/redcap/__init__.py
@@ -18,4 +18,3 @@ Other API requests are available, such as exporting users & Form-Event Mappings.
 
 from .project import Project
 from .request import RCRequest, RCAPIError, RedcapError
-from .version import VERSION as __version__

--- a/redcap/__init__.py
+++ b/redcap/__init__.py
@@ -4,6 +4,7 @@
 __author__ = 'Scott Burns <scott.s.burns@gmail.com>'
 __license__ = 'MIT'
 __copyright__ = '2014, Vanderbilt University'
+__version__ = '1.0.2'
 
 """
 This module exposes the REDCap API through the Project class. Instantiate the

--- a/redcap/version.py
+++ b/redcap/version.py
@@ -1,8 +1,0 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-__author__ = 'Scott Burns <scott.s.burns@gmail.com>'
-__license__ = 'MIT'
-__copyright__ = '2014, Vanderbilt University'
-
-VERSION = '1.0.2'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,24 @@ __author__ = 'Scott Burns <scott.s.burns@gmail.com>'
 __license__ = 'MIT'
 __copyright__ = '2014, Vanderbilt University'
 
+import codecs
 import os
+import re
+
+# Taken from vulture setup.py: https://github.com/jendrikseipp/vulture/blob/master/setup.py
+def read(*parts):
+    here = os.path.abspath(os.path.dirname(__file__))
+    with codecs.open(os.path.join(here, *parts), "r") as f:
+        return f.read()
+
+def find_version(*file_parts):
+    version_file = read(*file_parts)
+    version_match = re.search(
+        r"^__version__ = ['\"]([^'\"]*)['\"]$", version_file, re.M
+    )
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
 
 try:
     from setuptools import setup
@@ -29,7 +46,7 @@ if __name__ == '__main__':
         description="""PyCap: Python interface to REDCap""",
         license='MIT',
         url='http://sburns.github.com/PyCap',
-        version='1.0.2',
+        version=find_version("redcap", "__init__.py"),
         download_url='http://sburns.github.com/PyCap',
         long_description=long_desc,
         packages=['redcap'],

--- a/setup.py
+++ b/setup.py
@@ -12,14 +12,6 @@ try:
 except ImportError:
     from distutils.core import setup
 
-
-def get_version():
-    base = os.path.dirname(__file__)
-    with open(os.path.join(base, 'redcap/version.py')) as f:
-        VERSION = None
-        exec(f.read())
-        return VERSION
-
 required = [
     'requests>=1.0.0',
     'semantic-version>=2.3.1'
@@ -37,7 +29,7 @@ if __name__ == '__main__':
         description="""PyCap: Python interface to REDCap""",
         license='MIT',
         url='http://sburns.github.com/PyCap',
-        version=get_version(),
+        version='1.0.2',
         download_url='http://sburns.github.com/PyCap',
         long_description=long_desc,
         packages=['redcap'],


### PR DESCRIPTION
Fixes #87

I saw that you had the versioning in it's own file before, but I think that wasn't getting picked up when doing GitHub installs.

I thought this would be the most straightforward solution since:
* The information in `version.py` seems to be else where in the package such as the `__init__.py` and also the `setup.py`
* As far as I could tell they're wasn't a huge benefit to having the version in the `__init__.py` AND in the `setup.py`, though I could be missing something.
* This seems a little easier to bump the version, by just changing it in the `setup.py`
