### PR TITLE
Allow multiple record deletions

### DIFF
--- a/redcap/project.py
+++ b/redcap/project.py
@@ -237,21 +237,19 @@ class Project(object):
                 df_kwargs = {'index_col': 'field_name'}
             return read_csv(StringIO(response), **df_kwargs)
 
-    def delete_records(self, records, format='json'):
+    def delete_records(self, records):
         """
         Delete records from the Project.
 
         Parameters
-        __________
+        ----------
         records : list
             List of record IDs that you want to delete from the project
 
-        format : (``'json'``), ``'csv'``, ``'xml'``, ``'df'``
-            Return the metadata in native objects, csv or xml.
-            ``'df'`` will return a ``pandas.DataFrame``.
         Returns
-        _______
-        None
+        -------
+        response : int
+            Number of records deleted
         """
         pl = dict()
         pl['action'] = 'delete'
@@ -264,9 +262,8 @@ class Project(object):
         pl.update(records_dict)
 
         pl['format'] = format
-        response, _ = self._call_api(pl,'del_record')
-        if format in ('json', 'csv', 'xml'):
-            return response
+        response, _ = self._call_api(pl, 'del_record')
+        return response
 
     def export_records(self, records=None, fields=None, forms=None,
     events=None, raw_or_label='raw', event_name='label',

--- a/redcap/project.py
+++ b/redcap/project.py
@@ -237,14 +237,14 @@ class Project(object):
                 df_kwargs = {'index_col': 'field_name'}
             return read_csv(StringIO(response), **df_kwargs)
 
-    def delete_record(self, record, format='json'):
+    def delete_records(self, records, format='json'):
         """
-        Delete a record form the Project.
+        Delete records from the Project.
 
         Parameters
         __________
-        record : string
-            The record ID that you wan to delete from the project
+        records : list
+            List of record IDs that you want to delete from the project
 
         format : (``'json'``), ``'csv'``, ``'xml'``, ``'df'``
             Return the metadata in native objects, csv or xml.
@@ -257,7 +257,12 @@ class Project(object):
         pl['action'] = 'delete'
         pl['content'] = 'record'
         pl['token'] = self.token
-        pl['records[0]'] = record
+        # Turn list of records into dict, and append to payload
+        records_dict = {
+            "records[{}]".format(idx): record for idx, record in enumerate(records)
+        }
+        pl.update(records_dict)
+
         pl['format'] = format
         response, _ = self._call_api(pl,'del_record')
         if format in ('json', 'csv', 'xml'):


### PR DESCRIPTION
Adding to the great work started in #77 to allow for multiple records to be deleted at one time, since the API allows this. This is an improvement over having to hit the API _for each_ record you want to delete.