### PR TITLE
Handle EmptyData error from pandas read_csv

### DIFF
--- a/test/test_project.py
+++ b/test/test_project.py
@@ -615,6 +615,24 @@ class ProjectTests(unittest.TestCase):
         self.assertIn('count', response)
         self.assertNotIn('error', response)
 
+    def test_export_records_handles_empty_data_error(self):
+        self.reg_proj._call_api = mock.Mock()
+        self.reg_proj._call_api.return_value = "\n", {}
+        df = self.reg_proj.export_records(format='df')
+        self.assertTrue(df.empty)
+
+    def test_export_fem_handles_empty_data_error(self):
+        self.reg_proj._call_api = mock.Mock()
+        self.reg_proj._call_api.return_value = "\n", {}
+        df = self.reg_proj.export_fem(format='df')
+        self.assertTrue(df.empty)
+
+    def test_export_metadata_handles_empty_data_error(self):
+        self.reg_proj._call_api = mock.Mock()
+        self.reg_proj._call_api.return_value = "\n", {}
+        df = self.reg_proj.export_metadata(format='df')
+        self.assertTrue(df.empty)
+
     @responses.activate
     def test_date_formatting(self):
         """Test date_format parameter"""


### PR DESCRIPTION
pandas `read_csv` will throw an `EmptyDataError` if given empty data (no columns and no rows).

This is possible when exporting records for a brand new REDCap project with no records. This change handles the error and returns an empty data frame for all calls to `read_csv`.
