### PR TITLE
Add dateRangeBegin and dateRangeEnd parameters

### DIFF
--- a/redcap/__init__.py
+++ b/redcap/__init__.py
@@ -4,7 +4,7 @@
 __author__ = 'Scott Burns <scott.s.burns@gmail.com>'
 __license__ = 'MIT'
 __copyright__ = '2014, Vanderbilt University'
-__version__ = '1.1.1'
+__version__ = '1.1.2'
 
 """
 This module exposes the REDCap API through the Project class. Instantiate the

--- a/redcap/project.py
+++ b/redcap/project.py
@@ -338,17 +338,11 @@ class Project(object):
         fields = self.backfill_fields(fields, forms)
         keys_to_add = (records, fields, forms, events,
         raw_or_label, event_name, export_survey_fields,
-        export_data_access_groups, export_checkbox_labels,
-        date_begin, date_end)
+        export_data_access_groups, export_checkbox_labels)
+
         str_keys = ('records', 'fields', 'forms', 'events', 'rawOrLabel',
         'eventName', 'exportSurveyFields', 'exportDataAccessGroups',
-        'exportCheckboxLabel', 'dateRangeBegin', 'dateRangeEnd')
-
-        if date_begin:
-            date_begin = parse(date_begin).strftime('%Y-%m-%d %H:%M:%S')
-
-        if date_end:
-            date_end = parse(date_end).strftime('%Y-%m-%d %H:%M:%S')
+        'exportCheckboxLabel')
 
         for key, data in zip(str_keys, keys_to_add):
             if data:
@@ -357,6 +351,13 @@ class Project(object):
                         pl["{}[{}]".format(key, i)] = value
                 else:
                     pl[key] = data
+
+        if date_begin:
+            pl["dateRangeBegin"] = \
+                parse(date_begin).strftime('%Y-%m-%d %H:%M:%S')
+
+        if date_end:
+            pl["dateRangeEnd"] = parse(date_end).strftime('%Y-%m-%d %H:%M:%S')
 
         if filter_logic:
             pl["filterLogic"] = filter_logic

--- a/redcap/project.py
+++ b/redcap/project.py
@@ -6,7 +6,6 @@ __license__ = 'MIT'
 __copyright__ = '2014, Vanderbilt University'
 
 import json
-from dateutil.parser import parse
 import warnings
 
 from .request import RCRequest, RedcapError, RequestException
@@ -321,9 +320,9 @@ class Project(object):
             export.
         filter_logic : string
             specify the filterLogic to be sent to the API.
-        date_begin : string
+        date_begin : datetime
             for the dateRangeStart filtering of the API
-        date_end : string
+        date_end : datetime
             for the dateRangeEnd filtering snet to the API
 
         Returns
@@ -353,11 +352,10 @@ class Project(object):
                     pl[key] = data
 
         if date_begin:
-            pl["dateRangeBegin"] = \
-                parse(date_begin).strftime('%Y-%m-%d %H:%M:%S')
+            pl["dateRangeBegin"] = date_begin.strftime('%Y-%m-%d %H:%M:%S')
 
         if date_end:
-            pl["dateRangeEnd"] = parse(date_end).strftime('%Y-%m-%d %H:%M:%S')
+            pl["dateRangeEnd"] = date_end.strftime('%Y-%m-%d %H:%M:%S')
 
         if filter_logic:
             pl["filterLogic"] = filter_logic

--- a/redcap/project.py
+++ b/redcap/project.py
@@ -6,6 +6,7 @@ __license__ = 'MIT'
 __copyright__ = '2014, Vanderbilt University'
 
 import json
+from dateutil.parser import parse
 import warnings
 
 from .request import RCRequest, RedcapError, RequestException
@@ -267,7 +268,8 @@ class Project(object):
     events=None, raw_or_label='raw', event_name='label',
     format='json', export_survey_fields=False,
     export_data_access_groups=False, df_kwargs=None,
-    export_checkbox_labels=False, filter_logic=None):
+    export_checkbox_labels=False, filter_logic=None,
+    date_begin=None, date_end=None):
         """
         Export data from the REDCap project.
 
@@ -319,6 +321,10 @@ class Project(object):
             export.
         filter_logic : string
             specify the filterLogic to be sent to the API.
+        date_begin : string
+            for the dateRangeStart filtering of the API
+        date_end : string
+            for the dateRangeEnd filtering snet to the API
 
         Returns
         -------
@@ -332,10 +338,18 @@ class Project(object):
         fields = self.backfill_fields(fields, forms)
         keys_to_add = (records, fields, forms, events,
         raw_or_label, event_name, export_survey_fields,
-        export_data_access_groups, export_checkbox_labels)
+        export_data_access_groups, export_checkbox_labels,
+        date_begin, date_end)
         str_keys = ('records', 'fields', 'forms', 'events', 'rawOrLabel',
         'eventName', 'exportSurveyFields', 'exportDataAccessGroups',
-        'exportCheckboxLabel')
+        'exportCheckboxLabel', 'dateRangeBegin', 'dateRangeEnd')
+
+        if date_begin:
+            date_begin = parse(date_begin).strftime('%Y-%m-%d %H:%M:%S')
+
+        if date_end:
+            date_end = parse(date_end).strftime('%Y-%m-%d %H:%M:%S')
+
         for key, data in zip(str_keys, keys_to_add):
             if data:
                 if key in ('fields', 'records', 'forms', 'events'):
@@ -699,7 +713,7 @@ class Project(object):
         if event:
             pl['event'] = event
         return self._call_api(pl, 'exp_survey_participant_list')
-    
+
     def generate_next_record_name(self):
         pl = self.__basepl(content='generateNextRecordName')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ semantic-version==2.3.1
 requests>=1.1.0
 wheel==0.22.0
 responses==0.9.0
-python-dateutil==2.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ semantic-version==2.3.1
 requests>=1.1.0
 wheel==0.22.0
 responses==0.9.0
+python-dateutil==2.8.1


### PR DESCRIPTION
Im relatively new to REDCap and have found this library very helpful. It looks as if work was discontinued on the project before the date range filtering was added to the Export Records call. My use case requires using this, so I went ahead and forked and made the simple change.

I just followed the template in the code and added two new keys to the data payload. I use the dateutil.parser.parse method to make it so the input values for the dates can be a little flexible. This meant updating requirements.txt as well.

I didn't see any appropriate tests to modify.

I'm opening this issue here, and will attach a pull request. This is my first github pull request, so feedback welcome.

Fixes #123 