### PR TITLE
Add _complete fields to payload when requesting survey fields.

### DIFF
--- a/redcap/project.py
+++ b/redcap/project.py
@@ -425,6 +425,9 @@ class Project(object):
             "exportCheckboxLabel",
         )
 
+        if export_survey_fields:
+            fields = fields.extend([name + "_complete" for name in self.forms])
+
         for key, data in zip(str_keys, keys_to_add):
             if data:
                 if key in ("fields", "records", "forms", "events"):


### PR DESCRIPTION
Having access to _complete fields is very helpful when processing data from projects with a lot of forms. I have tested this against several projects and it doesn't seem to cause problems, although more testing is a good idea.