### PR TITLE
:bug: Fix generate_next_record_name method

### DIFF
--- a/redcap/methods/records.py
+++ b/redcap/methods/records.py
@@ -437,7 +437,7 @@ class Records(Base):
         response = self._call_api(payload, return_type)
         return response
 
-    def generate_next_record_name(self) -> int:
+    def generate_next_record_name(self) -> str:
         """
         Get the next record name
 
@@ -446,10 +446,12 @@ class Records(Base):
 
         Examples:
             >>> proj.generate_next_record_name()
-            3
+            '3'
         """
+        # Force the csv format here since if the project uses data access groups
+        # or just non-standard record names then the result will not be JSON-compliant
         payload = self._initialize_payload(
-            content="generateNextRecordName", format_type="json"
+            content="generateNextRecordName", format_type="csv"
         )
 
-        return self._call_api(payload, return_type="int")
+        return self._call_api(payload, return_type="str")

--- a/tests/unit/test_simple_project.py
+++ b/tests/unit/test_simple_project.py
@@ -163,7 +163,7 @@ def test_user_export(simple_project):
 def test_generate_next_record_name(simple_project):
     next_name = simple_project.generate_next_record_name()
 
-    assert next_name == 123
+    assert next_name == "123"
 
 
 def test_delete_records(simple_project):


### PR DESCRIPTION
Trying to return json for `3` is fine. Trying to return json for `5220-3` is not fine, which is what this method will return if the project uses data access groups, and the user making the request is assigned to a data access group. 

Forcing this method to return a string is the best way to go since it's return format can't even be altered by the API request to begin with, and having non-standard record name means that a string is the safest value.

🤔 Maybe if this really annoys people, then we can leave it up to the user if they want to return the data as an `int` but it's really not that hard to do the conversion yourself.