### PR TITLE
:see_no_evil: Ignore redcap/conftest.py in codecov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,8 @@
 [report]
+# the doctests aren't run in forks
+omit =
+    redcap/conftest.py
+
 exclude_lines =
     pragma: no cover
     if TYPE_CHECKING:


### PR DESCRIPTION
Discovered in #210 

Fixing here so that future forked repos don't run into this issue in CI