### PR TITLE
allow passing kwargs to perform API requests

### DIFF
--- a/redcap/methods/base.py
+++ b/redcap/methods/base.py
@@ -39,12 +39,16 @@ FileMap = Tuple[bytes, dict]
 class Base:
     """Base attributes and methods for the REDCap API"""
 
-    def __init__(self, url: str, token: str, verify_ssl: Union[bool, str] = True):
+    def __init__(self, url: str, token: str, verify_ssl: Union[bool, str] = True, **request_kwargs):
         """Initialize a Project, validate url and token"""
         self._validate_url_and_token(url, token)
         self._url = url
         self._token = token
         self.verify_ssl = verify_ssl
+        
+        self._validate_request_kwargs(**request_kwargs)
+        self._request_kwargs = request_kwargs
+        
         # attributes which require API calls
         self._metadata = None
         self._forms = None
@@ -136,6 +140,14 @@ class Base:
             f"Incorrect token format '{ token }', token must must be",
             f"{ expected_token_len } characters long",
         )
+        
+    @staticmethod
+    def _validate_request_kwargs(**request_kwargs):
+        """Run basic validation on user supplied kwargs for requests"""
+        # list of kwargs hardcoded in _RCRequest.execute(...) and self._call_api(...)
+        hardcoded_kwargs = ["url", "data", "verify, verify_ssl", "return_headers", "files", "file"]
+        unallowed_kwargs = [kwarg for kwarg in request_kwargs if kwarg in hardcoded_kwargs]
+        assert len(unallowed_kwargs) == 0, f"Not allowed to define {unallowed_kwargs} when initiating object"
 
     # pylint: disable=import-outside-toplevel
     @staticmethod
@@ -513,5 +525,5 @@ class Base:
 
         rcr = _RCRequest(url=self.url, payload=payload, config=config)
         return rcr.execute(
-            verify_ssl=self.verify_ssl, return_headers=return_headers, file=file
+            verify_ssl=self.verify_ssl, return_headers=return_headers, file=file, **self._request_kwargs
         )

--- a/redcap/request.py
+++ b/redcap/request.py
@@ -161,6 +161,7 @@ class _RCRequest:
         verify_ssl: Union[bool, str],
         return_headers: Literal[True],
         file: Optional[FileUpload],
+        **kwargs,
     ) -> Tuple[Union[Json, str, bytes], dict]:
         ...
 
@@ -170,6 +171,7 @@ class _RCRequest:
         verify_ssl: Union[bool, str],
         return_headers: Literal[False],
         file: Optional[FileUpload],
+        **kwargs,
     ) -> Union[List[Dict[str, Any]], str, bytes]:
         ...
 
@@ -178,6 +180,7 @@ class _RCRequest:
         verify_ssl: Union[bool, str],
         return_headers: bool,
         file: Optional[FileUpload],
+        **kwargs,
     ):
         """Execute the API request and return data
 
@@ -187,6 +190,8 @@ class _RCRequest:
                 Whether or not response headers should be returned along
                 with the request content
             file: A file object to send along with the request
+            **kwargs: passed to requesets.request() to control 
+                the configuration to perform requests to the api
 
         Returns:
             Data object from JSON decoding process if format=='json',
@@ -198,7 +203,7 @@ class _RCRequest:
                 exist, field doesn't exist, etc.
         """
         response = self.session.post(
-            self.url, data=self.payload, verify=verify_ssl, files=file
+            self.url, data=self.payload, verify=verify_ssl, files=file, **kwargs
         )
 
         content = self.get_content(


### PR DESCRIPTION
Passing `request_kwargs` during instantiation of `Project()` to control how API requests are performed later on.

More detail to the use case and motivation is given here: https://github.com/redcap-tools/PyCap/issues/249