### PR TITLE
Handle 500 Internal Server Error with RedcapError

### DIFF
--- a/redcap/request.py
+++ b/redcap/request.py
@@ -186,6 +186,9 @@ class _RCRequest:
             self.url, data=self.payload, verify=verify_ssl, files=file, **kwargs
         )
 
+        if response.status_code == 500:
+            raise RedcapError(f"HTTP error 500 {response.reason}")
+
         content = self.get_content(
             response,
             format_type=self.fmt,

--- a/redcap/request.py
+++ b/redcap/request.py
@@ -16,7 +16,7 @@ from typing import (
     overload,
 )
 
-from requests import RequestException, Response, Session
+from requests import RequestException, Response, Session, JSONDecodeError
 
 if TYPE_CHECKING:
     from io import TextIOWrapper
@@ -150,7 +150,10 @@ class _RCRequest:
             return [{}]
 
         if format_type == "json":
-            return response.json()
+            try:
+                return response.json()
+            except JSONDecodeError as jde:
+                raise RedcapError("Unable to decode response as JSON") from jde
 
         # don't do anything to csv/xml strings
         return response.text


### PR DESCRIPTION
Fixes #261.

Also raises a RedcapError from any JSONDecodeError in the response.json() call, but this can be reverted if it's too out of scope for this PR.