### PR TITLE
coerce field and form arguments in export_records()

### DIFF
--- a/redcap/methods/records.py
+++ b/redcap/methods/records.py
@@ -178,6 +178,12 @@ class Records(Base):
             content="record", format_type=format_type, record_type=record_type
         )
 
+        if isinstance(str, fields):
+            fields = [fields]
+
+        if isinstance(str, forms):
+            forms = [forms]
+
         fields = self._backfill_fields(fields, forms)
 
         keys_to_add = (

--- a/redcap/methods/records.py
+++ b/redcap/methods/records.py
@@ -88,9 +88,9 @@ class Records(Base):
                 fields to pull.
                 By default, all fields are exported
             forms:
-                Single form name or array of form names to export. If in the 
-                web UI, the form name has a space in it, replace the space 
-                with an underscore. 
+                Single form name or array of form names to export. If in the
+                web UI, the form name has a space in it, replace the space
+                with an underscore.
                 By default, all forms are exported
             events:
                 An array of unique event names from which to export records

--- a/redcap/methods/records.py
+++ b/redcap/methods/records.py
@@ -180,10 +180,10 @@ class Records(Base):
             content="record", format_type=format_type, record_type=record_type
         )
 
-        if isinstance(str, fields):
+        if isinstance(fields, str):
             fields = [fields]
 
-        if isinstance(str, forms):
+        if isinstance(forms, str):
             forms = [forms]
 
         fields = self._backfill_fields(fields, forms)

--- a/redcap/methods/records.py
+++ b/redcap/methods/records.py
@@ -54,8 +54,8 @@ class Records(Base):
         self,
         format_type: Literal["json", "csv", "xml", "df"] = "json",
         records: Optional[List[str]] = None,
-        fields: Optional[List[str]] = None,
-        forms: Optional[List[str]] = None,
+        fields: Optional[Union[List[str], str]] = None,
+        forms: Optional[Union[List[str], str]] = None,
         events: Optional[List[str]] = None,
         raw_or_label: Literal["raw", "label", "both"] = "raw",
         raw_or_label_headers: Literal["raw", "label"] = "raw",
@@ -84,11 +84,13 @@ class Records(Base):
                 Array of record names specifying specific records to export.
                 By default, all records are exported
             fields:
-                Array of field names specifying specific fields to pull
-                by default, all fields are exported
+                Single field name or array of field names specifying specific
+                fields to pull.
+                By default, all fields are exported
             forms:
-                Array of form names to export. If in the web UI, the form
-                name has a space in it, replace the space with an underscore
+                Single form name or array of form names to export. If in the 
+                web UI, the form name has a space in it, replace the space 
+                with an underscore. 
                 By default, all forms are exported
             events:
                 An array of unique event names from which to export records

--- a/tests/unit/test_simple_project.py
+++ b/tests/unit/test_simple_project.py
@@ -482,7 +482,7 @@ def test_export_always_include_def_field(simple_project):
     integration test that will test it for real
     """
     # If we just ask for a form, must also get def_field in there
-    records = simple_project.export_records(forms=["imaging"])
+    records = simple_project.export_records(forms="imaging")
     for record in records:
         assert simple_project.def_field in record
     # still need it def_field even if not asked for in form and fields
@@ -490,7 +490,7 @@ def test_export_always_include_def_field(simple_project):
     for record in records:
         assert simple_project.def_field in record
     # If we just ask for some fields, still need def_field
-    records = simple_project.export_records(fields=["foo_score"])
+    records = simple_project.export_records(fields="foo_score")
     for record in records:
         assert simple_project.def_field in record
     records = simple_project.export_records(fields=["record_id", "foo_score"])


### PR DESCRIPTION
Implements https://github.com/redcap-tools/PyCap/issues/262. 

Change the expected argument type from `List[str]` to `Union[List[str], str]` and coerce if required the argument from `str` to `List[str]` before starting the processing.